### PR TITLE
Adding find-in-range

### DIFF
--- a/src/ESeries.stanza
+++ b/src/ESeries.stanza
@@ -8,6 +8,9 @@ public defstruct InvalidValue <: Exception : (msg:String)
 defmethod print (o:OutputStream, e:InvalidValue) :
   print(o, "Invalid Value: %_" % [msg(e)])
 
+public defn in-range (v:Double, minV:Double, maxV:Double) -> True|False : 
+  (v >= minV) and (v <= maxV)
+
 public defn round-places (v:Double, places:Int) -> Double :
   ; Round off the decimal places for a value.
   ;  @param v This value is expected to be in the range from 0.0 - 10.0
@@ -61,6 +64,9 @@ public defmulti series-tolerance (self:ESeries) -> Double
 public defmulti get-series (self:ESeries) -> Tuple<Double>
 ; Find the closest value in this series to the passed `v` parameter.
 public defmulti find-nearest (self:ESeries, v:Double) -> Double
+; Find all the resistors of this series that are 
+;  found with in the given bounds. 
+public defmulti find-in-range (self:ESeries, minV:Double, maxV:Double) -> Tuple<Double>
 
 public defmethod get-series (self:ESeries) -> Tuple<Double> :
   ; Conceptually I see the series as imutable, hence the use of Tuple
@@ -68,6 +74,7 @@ public defmethod get-series (self:ESeries) -> Tuple<Double> :
   val N = elements(self)
   val ret = map(rounded-log10{_, N, places(self)}, 0 to N)
   to-tuple(ret)
+
 
 public defmethod find-nearest (self:ESeries, v:Double) -> Double :
   ; Find the closest value in this series. 
@@ -83,6 +90,26 @@ public defmethod find-nearest (self:ESeries, v:Double) -> Double :
   qsort!(get{_,0}, errVals)
   errVals[0][1]
   
+public defmethod find-in-range (self:ESeries, minV:Double, maxV:Double) -> Tuple<Double> : 
+  if not (minV < maxV) :
+    throw(InvalidValue(to-string("Expects minV < maxV : %_ < %_ " % [minV, maxV])))
+
+  val minPwr10 = get-power-of-10(minV)
+  val maxPwr10 = get-power-of-10(maxV)
+
+  var ranges:List<Array<Double>> = List()
+
+  val series = get-series(self)
+  for i in to-int(minPwr10) to to-int(maxPwr10) + 1 do:
+    val RRange = to-array<Double>(series)
+    map!(scaled-series{_ , to-double(i)}, RRange)
+    ranges = cons(RRange, ranges)
+
+  val searchSpace:Seq<Double> = cat-all(ranges)
+  val restrictedSpace = to-array<Double>(filter(in-range{_, minV, maxV}, searchSpace))
+  qsort!(restrictedSpace)
+  to-tuple(restrictedSpace)
+
 
 public deftype E12 <: ESeries
 public deftype E24 <: ESeries

--- a/src/ESeries.stanza
+++ b/src/ESeries.stanza
@@ -41,6 +41,11 @@ public defn rounded-log10 (v:Int, N:Int, places:Int) -> Double :
 
   round-places(pow(10.0, to-double(v) / to-double(N)), places)
 
+public defn scaled-series (x:Double, exp:Double) -> Double :
+  ;  Convert a particular series value and an exponent into a 
+  ;   scaled series value.
+  x * pow(10.0, exp)
+
 ; E-series Preferred numbers
 ; https://en.wikipedia.org/wiki/E_series_of_preferred_numbers
 public deftype ESeries
@@ -71,7 +76,7 @@ public defmethod find-nearest (self:ESeries, v:Double) -> Double :
   ;    determine what the nearest value in the series for that power of ten is.
   val pwr10 = get-power-of-10(v)
   val series = to-array<Double>(get-series(self))
-  map!({_ * pow(10.0, pwr10)}, series)
+  map!(scaled-series{_ , pwr10}, series)
   val err = map<Double>({abs(_ - v)}, series)
   val errVals = to-array<[Double, Double]>(zip(err, series))
 

--- a/src/ESeries.stanza
+++ b/src/ESeries.stanza
@@ -57,7 +57,7 @@ public defmulti name (self:ESeries) -> String
 public defmulti elements (self:ESeries) -> Int
 public defmulti places (self:ESeries) -> Int
 ; Nominal Tolerance for this Series of values as a 
-;  "Percentage" value (0-1.0)
+;  "Percentage" value 0-100.0
 public defmulti series-tolerance (self:ESeries) -> Double
 ; Get the Values that constitute the closed sequence of 
 ;  this series. 
@@ -120,7 +120,7 @@ public defn E12 () -> E12 :
   val name = "E12"
   val elements = 12
   val places = 2
-  val tolerance = 0.1
+  val tolerance = 10.0
   new E12 : 
     defmethod name (this) : name
     defmethod elements (this) : elements
@@ -137,7 +137,7 @@ public defn E24 () -> E24 :
   val name = "E24"
   val elements = 24
   val places = 2
-  val tolerance = 0.05
+  val tolerance = 5.0
   new E24 : 
     defmethod name (this) : name
     defmethod elements (this) : elements
@@ -157,7 +157,7 @@ public defn E48 () -> E48 :
   val name = "E48"
   val elements = 48
   val places = 3
-  val tolerance = 0.02
+  val tolerance = 2.0
   new E48 : 
     defmethod name (this) : name
     defmethod elements (this) : elements
@@ -168,7 +168,7 @@ public defn E96 () -> E96 :
   val name = "E96"
   val elements = 96
   val places = 3
-  val tolerance = 0.01
+  val tolerance = 1.0
   new E96 : 
     defmethod name (this) : name
     defmethod elements (this) : elements

--- a/src/jitx/ESeries.stanza
+++ b/src/jitx/ESeries.stanza
@@ -4,13 +4,26 @@ defpackage etools/jitx/ESeries :
   import jitx
   import etools/ESeries
 
+
+; Convert a raw value to the toleranced version 
+;   from this series.
+public defmulti get-toleranced (self:ESeries, v:Double) -> Toleranced
+
 ; Find the closest value matching the passed `v` parameter and then 
 ;   return a Toleranced value that includes the series value and its
 ;   associated tolerances.
 public defmulti find-toleranced (self:ESeries, v:Double) -> Toleranced
+public defmulti find-in-range (self:ESeries, v:Toleranced) -> Tuple<Toleranced>
+
+public defmethod get-toleranced (self:ESeries, v:Double) -> Toleranced :
+  tol%(v, 100.0 * series-tolerance(self))
 
 public defmethod find-toleranced (self:ESeries, v:Double) -> Toleranced :
   ; Find the nearest resistor value and return as a toleranced
   ;   value. 
   val nearVal = find-nearest(self, v)
   tol%(nearVal, 100.0 * series-tolerance(self))
+
+public defmethod find-in-range (self:ESeries, v:Toleranced) -> Tuple<Toleranced> :
+  val vals = find-in-range(self, min-value(v), max-value(v))
+  map(tol%{_, 100.0 * series-tolerance(self)}, vals)

--- a/src/jitx/ESeries.stanza
+++ b/src/jitx/ESeries.stanza
@@ -16,14 +16,14 @@ public defmulti find-toleranced (self:ESeries, v:Double) -> Toleranced
 public defmulti find-in-range (self:ESeries, v:Toleranced) -> Tuple<Toleranced>
 
 public defmethod get-toleranced (self:ESeries, v:Double) -> Toleranced :
-  tol%(v, 100.0 * series-tolerance(self))
+  tol%(v, series-tolerance(self))
 
 public defmethod find-toleranced (self:ESeries, v:Double) -> Toleranced :
   ; Find the nearest resistor value and return as a toleranced
   ;   value. 
   val nearVal = find-nearest(self, v)
-  tol%(nearVal, 100.0 * series-tolerance(self))
+  tol%(nearVal, series-tolerance(self))
 
 public defmethod find-in-range (self:ESeries, v:Toleranced) -> Tuple<Toleranced> :
   val vals = find-in-range(self, min-value(v), max-value(v))
-  map(tol%{_, 100.0 * series-tolerance(self)}, vals)
+  map(tol%{_, series-tolerance(self)}, vals)

--- a/tests/ESeries_jitx_tests.stanza
+++ b/tests/ESeries_jitx_tests.stanza
@@ -7,12 +7,28 @@ defpackage etools/ESeries/jitx-tests :
   import etools/jitx/ESeries
   import jitx
 
+deftest get-toleranced-test :
+  val series = E24()
+
+  val t = get-toleranced(series, 120.0)
+  #EXPECT(typ(t) == 120.0)
+  #EXPECT(min-value(t) == 120.0 * 0.95)
+  #EXPECT(max-value(t) == 120.0 * 1.05)
 
 deftest find-toleranced-test :
-    val series = E96()
+  val series = E96()
 
-    val obs = find-toleranced(series, 120.0)    
-    val exp = tol%(121.0, 1.0)
-    #EXPECT(obs == exp)
+  val obs = find-toleranced(series, 120.0)    
+  val exp = tol%(121.0, 1.0)
+  #EXPECT(obs == exp)
 
+deftest find-in-range-toleranced : 
+  
+  val series = E12()
+  val r = min-max(70.0, 130.0)
+  val vals = find-in-range(series, r)
+
+  val expVals = [82.0, 100.0, 120.0]
     
+  #EXPECT(length(vals) == length(expVals))
+

--- a/tests/ESeries_tests.stanza
+++ b/tests/ESeries_tests.stanza
@@ -30,6 +30,24 @@ val epsilon = 1.0e-3
       val msg = to-string(buf) 
       [true, msg]
 
+deftest in-range-test : 
+  val testVecs = [
+    [1.0, 0.0, 10.0, true]
+    [-1.0, 0.0, 10.0, false]    
+    [-1.0, -10.0, 10.0, true]
+    [-9.0, -10.0, 10.0, true]
+    [9.0, -10.0, 10.0, true]
+    [-10.1, -10.0, 10.0, false]
+    [10.1, -10.0, 10.0, false]
+    [9.0, -10.0, -1.0, false]
+    [-9.0, -10.0, -1.0, true]
+  ]
+
+  for testVec in testVecs do :
+    val [v, minV, maxV, expVal] = testVec 
+    val obsVal = in-range(v, minV, maxV)
+    #EXPECT(expVal == obsVal)
+
 deftest round-places-tests :
 
   val testVecs = [
@@ -230,3 +248,35 @@ deftest E96-test :
   obs = find-nearest(series, 203.3)
   #EXPECT(almost-equal(obs, 205.0, epsilon))
 
+deftest find-in-range-test :
+  val testVecs = [
+    ; Inside a single Range
+    [E96(), 95.0, 98.0, [95.3, 97.6]],
+    ; Spanning a range edge
+    [E96(), 95.0, 110.0, [95.3, 97.6, 100.0, 102.0, 105.0, 107.0]],
+    ; Spanning multiple ranges.
+    [E12(), 9.0, 130.0, [10.0, 12.0, 15.0, 18.0, 22.0, 27.0, 33.0, 39.0, 47.0, 56.0, 68.0, 82.0 100.0, 120.0]]
+  ]
+
+  for testVec in testVecs do :
+    val [series, minVal, maxVal, expVal] = testVec 
+    val obsVal = find-in-range(series, minVal, maxVal)
+    #EXPECT(length(expVal) == length(obsVal))
+    
+    val faults = check-not-equal(obsVal, expVal, epsilon)
+    if length(faults) > 0: 
+      val msg = string-join(faults, "\n")
+      println("Faults: %_" % [msg])
+      #EXPECT(length(faults) == 0)
+
+  val failVecs = [
+    [{find-in-range(E24(), 200.5, 3.0)}, "Expects minV < maxV : 200.5 < 3.0"]
+  ]
+
+  for failVec in failVecs do : 
+    ; Test that exceptions throw in the way we expect
+    val [f, msgClip] = failVec
+    val [throws, msg] = expect-throw(f)
+    #EXPECT(throws)
+    #EXPECT(index-of-chars(msg, "Invalid Value") != false)
+    #EXPECT(index-of-chars(msg, msgClip) != false)

--- a/tests/ESeries_tests.stanza
+++ b/tests/ESeries_tests.stanza
@@ -128,7 +128,7 @@ deftest E12-test :
 
   #EXPECT( name(series) == "E12" )
   #EXPECT( elements(series) == 12 )
-  #EXPECT( series-tolerance(series) == 0.10 )
+  #EXPECT( series-tolerance(series) == 10.0 )
   
   val s10 = get-series(series)
 
@@ -155,7 +155,7 @@ deftest E24-test :
 
   #EXPECT( name(series) == "E24" )
   #EXPECT( elements(series) == 24 )
-  #EXPECT( series-tolerance(series) == 0.05 )
+  #EXPECT( series-tolerance(series) == 5.0 )
 
   val s5 = get-series(series)
 
@@ -183,7 +183,7 @@ deftest E48-test :
 
   #EXPECT( name(series) == "E48" )
   #EXPECT( elements(series) == 48 )
-  #EXPECT( series-tolerance(series) == 0.02 )
+  #EXPECT( series-tolerance(series) == 2.0 )
 
   val s2 = get-series(series)
 
@@ -216,7 +216,7 @@ deftest E96-test :
 
   #EXPECT( name(series) == "E96" )
   #EXPECT( elements(series) == 96 )
-  #EXPECT( series-tolerance(series) == 0.01 )
+  #EXPECT( series-tolerance(series) == 1.0 )
 
   val s1 = get-series(series)
 


### PR DESCRIPTION
This adds a new utility that allows for discovering the available resistor values in a series between two min and max bounding values. 

For example - 

```
val series = E96()
val avail = find-in-range(series, 95.0, 98.0)
println("Available: %," % [avail])
```

Should show: 

```
Available: 95.3, 97.6
```

This also adds the `Toleranced` versions of this method for the jitx interface.