### PR TITLE
Network Module for 2-pin Lumped Element Circuits

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,8 @@
                 "${workspaceFolder}/tests/NumTools_tests.stanza",
                 "${workspaceFolder}/tests/Geometry_tests.stanza",
                 "${workspaceFolder}/tests/Solvers.stanza",
+                "${workspaceFolder}/tests/Network.stanza",
+                "${workspaceFolder}/tests/CanonicalGround_test.stanza",
             ],
             "group": "test",
             "presentation": {

--- a/src/jitx/CanonicalGround.stanza
+++ b/src/jitx/CanonicalGround.stanza
@@ -32,6 +32,16 @@ public defn disable-ground-pin (p : JITXObject ) :
     if has-property?(p.canonical-gorund) :
       property(p.canonical-ground) = false
 
+public defn is-grounded? (p:JITXObject) -> True|False :
+  inside pcb-component :
+    ; if has-property?(p.canonical-ground):
+    ;   val ret:True|False = property(p.canonical-ground)
+    ;   ret
+    ; else:
+    ;   false
+    has-property?(p.canonical-ground) and property(p.canonical-ground)
+
+
 public defn shunt-comp (p:JITXObject, make-comp, params : Tuple<KeyValue>):
   ; Shunt Component to ground through the generated component definition
   ;  created by `make-comp`
@@ -67,19 +77,18 @@ public defn with-ground (gnd : Net) :
   ;
   ; This function will go through all of the components and sub-modules
   ;   in the module where this function is called. For each component
-  ;   or sub-module - we will  look for the "canonical-ground" property. 
+  ;   or sub-module - we will  look for the "canonical-ground" property.
   ; If:
   ;   1. The property is found
   ;   2. and the property is true
   ;  We will connect to the passed ground Net object.
-  ; 
+  ;
   ; @NOTE - We can't check for `connected?` on the pin of the module
-  ;   or component because for sub-modules, the pin will likely be 
+  ;   or component because for sub-modules, the pin will likely be
   ;   connected to something internal to the module.
   ;  and true - then we will
   inside pcb-module:
     for i in instances(self) do :
       for p in pins(i) do :
-        if has-property?(p.canonical-ground) :
-          if property(p.canonical-ground) :
-            net (gnd, p)
+        if is-grounded?(p):
+          net (gnd, p)

--- a/src/jitx/CanonicalGround.stanza
+++ b/src/jitx/CanonicalGround.stanza
@@ -4,6 +4,7 @@ defpackage etools/jitx/CanonicalGround :
   import jitx
   import jitx/commands
   import ocdb/utils/generic-components
+  import etools/jitx/Utils
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;
@@ -34,13 +35,7 @@ public defn disable-ground-pin (p : JITXObject ) :
 
 public defn is-grounded? (p:JITXObject) -> True|False :
   inside pcb-component :
-    ; if has-property?(p.canonical-ground):
-    ;   val ret:True|False = property(p.canonical-ground)
-    ;   ret
-    ; else:
-    ;   false
     has-property?(p.canonical-ground) and property(p.canonical-ground)
-
 
 public defn shunt-comp (p:JITXObject, make-comp, params : Tuple<KeyValue>):
   ; Shunt Component to ground through the generated component definition
@@ -88,7 +83,7 @@ public defn with-ground (gnd : Net) :
   ;   connected to something internal to the module.
   ;  and true - then we will
   inside pcb-module:
-    for i in instances(self) do :
+    for i in instances-rec(self) do :
       for p in pins(i) do :
         if is-grounded?(p):
           net (gnd, p)

--- a/src/jitx/Network.stanza
+++ b/src/jitx/Network.stanza
@@ -273,7 +273,7 @@ public defn make-circuit (a:ANT) -> Instantiable :
     for tap in taps do:
       val [name, pinObj] = tap
       if name == "p":
-        fatal("Invalid Tap Name '%_' - Must be unique in 'network-circuit'")
+        fatal("Invalid Tap Name '%_' - Must be unique in 'network-circuit'" % [name])
       val namedPort = make-port(to-symbol(name), SinglePin())
       net (namedPort, pinObj)
 

--- a/src/jitx/Network.stanza
+++ b/src/jitx/Network.stanza
@@ -138,10 +138,10 @@ public defn Parallel () -> Parallel :
 
 public deftype ShuntGround <: ANT
 
-public defn ShuntGround (a:ANT) -> Shunt :
+public defn ShuntGround (a:ANT) -> ShuntGround :
   val elem = a
 
-  new Shunt :
+  new ShuntGround :
     defmethod get-op (this) : SHUNT-GND
     defmethod get-elements (this) : [elem]
     defmethod print (o:OutputStream, this) :
@@ -209,11 +209,17 @@ public defn connect-parallel (a:Parallel, taps:Vector<[String,JITXObject]>) -> [
     val pinSets = to-tuple(extrapolate-all(a, taps))
     val cnt = length(pinSets)
 
-    ; @TODO - for `shunt` to really do anything - I think I need to
-    ;    check if any of the pins are already connected to ground.
-    ;    We should filter out any that have the canonical-ground property
-    val p1Set = map(get{_, 0}, pinSets)
-    val p2Set = map(get{_, 1}, pinSets)
+    ; Often it is useful to have a `ShuntGround` in the parallel components.
+    ;   If we force this to connect in parallel though - it means all the
+    ;   components get connected to ground which is probably not what we want.
+    ;   So this filters out any pins with `canonical-ground` connections.
+    val notGrounded = {not is-grounded?(_)}
+    defn filter-pins (pSet:Tuple<[JITXObject, JITXObject]>, pinIdx:Int) :
+      to-tuple(filter(notGrounded, map(get{_, pinIdx}, pSet)))
+
+    val p1Set = filter-pins(pinSets, 0)
+    val p2Set = filter-pins(pinSets, 1)
+
     net (p1Set)
     net (p2Set)
 
@@ -232,13 +238,11 @@ public defn extrapolate (a:ANT, taps:Vector<[String,JITXObject]>) -> [JITXObject
         ;println("Extrapolate Component: %~" % [s])
         inst obj : get-value(s)
         get-pins(obj)
-      (s:Shunt):
+      (s:ShuntGround):
         ;println("Extrapolate Shunt: %~" % [s])
         val child = get-elements(s)[0]
         val [p1, p2] = extrapolate(child, taps)
-        val n = get-net(s)
-        ;println("Net: %~" % [n])
-        net (p2, n)
+        ground-pin(p2)
         [p1, p2]
       (s:Invert):
         ;println("Extrapolate Invert: %~" % [s])
@@ -311,6 +315,3 @@ public defn bit-or (a:ANT, b:Instantiable) -> ANT :
 
 public defn bit-or (a:Instantiable, b:ANT) -> ANT :
   Parallel([Comp(a), b])
-
-public defn shift-right (a:ANT, n:JITXObject) -> ANT :
-  Shunt(n, a)

--- a/src/jitx/Network.stanza
+++ b/src/jitx/Network.stanza
@@ -4,6 +4,7 @@ defpackage etools/jitx/Network :
   import collections
   import jitx
   import jitx/commands
+  import etools/jitx/CanonicalGround
 
 
 ; The concept of this code is to provide a means for defining a lumped
@@ -19,17 +20,21 @@ defpackage etools/jitx/Network :
 ;
 ;  1.  Series (+) - string multiple elements in series
 ;  2.  Parallel (|) - put multiple elements in parallel
-;  3.  Shunt - Connect a given node to a particular net through an element
-;         (For example, shunt to ground). Could also describe a pullup if needed.
+;  3.  Shunt Ground - Connect a given node to ground through an element
+;         This uses the `CanonicalGround` concept because `net` objects
+;         can't easily passed into the network. To connect to things other
+;         than ground - Taps are a tool for accomplishing this.
 ;  5.  Invert (~) - Instead of connecting 1 -> 2 , connect 2 -> 1. reverses the
 ;        orientation of the component. Useful for polarizing caps, diodes, etc.
+;  6.  TAP - For a particular node in the design
 
 public defenum NetOp:
   COMPONENT
   SERIES
   PARALLEL
-  SHUNT
+  SHUNT-GND
   INVERT
+  TAP
 
 ; ANT = Abstract Network Tree
 ;   ANT are the elements of the tree that might look something like this:
@@ -58,6 +63,29 @@ public defn Component (i:Instantiable) -> Component:
 
 public defn Comp (i:Instantiable) -> Component:
   Component(i)
+
+public deftype Tap <: ANT
+public defmulti get-name (a:ANT) -> String
+public defmulti get-pin-index (a:ANT) -> Int
+
+public defn Tap (name:String, a:ANT, pIndex:Int) -> Tap :
+  val n = name
+  val elem = a
+  if pIndex != 1 and pIndex != 2:
+    fatal("Invalid Pin Index for Tap - Must 1 or 2")
+
+  val idx = pIndex
+
+  new Tap:
+    defmethod get-op (this) : COMPONENT
+    defmethod get-elements (this) : [elem]
+    defmethod get-name (this) : n
+    defmethod get-pin-index (this) : idx
+    defmethod print (o:OutputStream, this):
+      print(o, "Tag(name='%_', idx=%_, %~)" % [n, idx, elem])
+
+public defn Tap (name:String, a:ANT) -> Tap :
+  Tap(name, a, 1)
 
 public deftype ANTVector <: ANT & Lengthable
 public defmulti add (v:ANTVector, elem:ANT) -> False
@@ -108,19 +136,16 @@ public defn Parallel (elems:Tuple<ANT>) -> Parallel:
 public defn Parallel () -> Parallel :
   Parallel([])
 
-public deftype Shunt <: ANT
-public defmulti get-net (s:Shunt) -> JITXObject
+public deftype ShuntGround <: ANT
 
-public defn Shunt (n:JITXObject, a:ANT) -> Shunt :
+public defn ShuntGround (a:ANT) -> Shunt :
   val elem = a
-  val _net = n
 
   new Shunt :
-    defmethod get-op (this) : SHUNT
+    defmethod get-op (this) : SHUNT-GND
     defmethod get-elements (this) : [elem]
-    defmethod get-net (this) : _net
     defmethod print (o:OutputStream, this) :
-      print(o, "Shunt(%~, net=%~)" % [a, n])
+      print(o, "ShuntGround(%~)" % [a])
 
 public deftype Invert <: ANT
 
@@ -162,14 +187,14 @@ public defn get-pins (obj:JITXObject) -> [JITXObject, JITXObject] :
     (_:None):
       [obj.p[1], obj.p[2]]
 
-public defn extrapolate-all (a:ANTVector) -> Seq<[JITXObject, JITXObject]> :
+public defn extrapolate-all (a:ANTVector, taps:Vector<[String,JITXObject]>) -> Seq<[JITXObject, JITXObject]> :
   inside pcb-module:
     for elem in get-elements(a) seq:
-      extrapolate(elem)
+      extrapolate(elem, taps)
 
-public defn connect-series (a:Series) -> [JITXObject, JITXObject] :
+public defn connect-series (a:Series, taps:Vector<[String,JITXObject]>) -> [JITXObject, JITXObject] :
   inside pcb-module:
-    val pinSets = to-tuple(extrapolate-all(a))
+    val pinSets = to-tuple(extrapolate-all(a, taps))
     val cnt = length(pinSets)
 
     ; Series connect all of the components
@@ -179,15 +204,14 @@ public defn connect-series (a:Series) -> [JITXObject, JITXObject] :
     ; Return the first pin and the last pin
     [pinSets[0][0], pinSets[cnt - 1][1]]
 
-public defn connect-parallel (a:Parallel) -> [JITXObject, JITXObject] :
+public defn connect-parallel (a:Parallel, taps:Vector<[String,JITXObject]>) -> [JITXObject, JITXObject] :
   inside pcb-module:
-    val pinSets = to-tuple(extrapolate-all(a))
+    val pinSets = to-tuple(extrapolate-all(a, taps))
     val cnt = length(pinSets)
 
     ; @TODO - for `shunt` to really do anything - I think I need to
-    ;    check if any of the pins are already connected.
-    ;    If one of the pins is already connected - then we should
-    ;    filter it out from this set.
+    ;    check if any of the pins are already connected to ground.
+    ;    We should filter out any that have the canonical-ground property
     val p1Set = map(get{_, 0}, pinSets)
     val p2Set = map(get{_, 1}, pinSets)
     net (p1Set)
@@ -195,15 +219,15 @@ public defn connect-parallel (a:Parallel) -> [JITXObject, JITXObject] :
 
     [p1Set[0], p2Set[0]]
 
-public defn extrapolate (a:ANT) -> [JITXObject, JITXObject] :
+public defn extrapolate (a:ANT, taps:Vector<[String,JITXObject]>) -> [JITXObject, JITXObject] :
   inside pcb-module :
     match(a) :
       (s:Series):
         ; println("Extrapolate Series: %~" % [s])
-        connect-series(s)
+        connect-series(s, taps)
       (s:Parallel):
         ;println("Extrapolate Parallel: %~" % [s])
-        connect-parallel(s)
+        connect-parallel(s, taps)
       (s:Component):
         ;println("Extrapolate Component: %~" % [s])
         inst obj : get-value(s)
@@ -211,7 +235,7 @@ public defn extrapolate (a:ANT) -> [JITXObject, JITXObject] :
       (s:Shunt):
         ;println("Extrapolate Shunt: %~" % [s])
         val child = get-elements(s)[0]
-        val [p1, p2] = extrapolate(child)
+        val [p1, p2] = extrapolate(child, taps)
         val n = get-net(s)
         ;println("Net: %~" % [n])
         net (p2, n)
@@ -219,17 +243,35 @@ public defn extrapolate (a:ANT) -> [JITXObject, JITXObject] :
       (s:Invert):
         ;println("Extrapolate Invert: %~" % [s])
         val child = get-elements(s)[0]
-        val [p1, p2] = extrapolate(child)
+        val [p1, p2] = extrapolate(child, taps)
         [p2, p1]
+      (s:Tap):
+        val child = get-elements(s)[0]
+        val childPins = extrapolate(child, taps)
+        ; val [p1, p2] = extrapolate(child, taps)
+        ; Add the tap here.
+        val tapPin = childPins[ get-pin-index(s) - 1 ]
+        val name = get-name(s)
+        add(taps, [name, tapPin])
+        childPins
 
 public defn make-circuit (a:ANT) -> Instantiable :
 
   pcb-module network-circuit:
-    ; pin p[[1 2]]
     port p : pin[[1 2]]
-    val [p1, p2] = extrapolate(a)
+    val taps = Vector<[String,JITXObject]>()
+    val [p1, p2] = extrapolate(a, taps)
     net (p[1], p1)
     net (p[2], p2)
+
+    ; Programmatically create ports for all the
+    ;   taps
+    for tap in taps do:
+      val [name, pinObj] = tap
+      if name == "p":
+        fatal("Invalid Tap Name '%_' - Must be unique in 'network-circuit'")
+      val namedPort = make-port(to-symbol(name), SinglePin())
+      net (namedPort, pinObj)
 
   network-circuit
 

--- a/src/jitx/Network.stanza
+++ b/src/jitx/Network.stanza
@@ -1,0 +1,274 @@
+#use-added-syntax(jitx)
+defpackage etools/jitx/Network :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+
+; The concept of this code is to provide a means for defining a lumped
+; circuit network tree. The idea is to provide a "DSL" for defining
+; components that are used together to form a circuit network.
+;
+; In this graph there are Elements and Nodes.
+;  Elements are the edges of the graph and are the resistors, capacitors, etc.
+;  Nodes are the pins, ground, nets, etc of the circuit
+
+; We can think of the circuit network as a graph. We have the following
+;  operations to this graph for 2-pin elements
+;
+;  1.  Series (+) - string multiple elements in series
+;  2.  Parallel (|) - put multiple elements in parallel
+;  3.  Shunt - Connect a given node to a particular net through an element
+;         (For example, shunt to ground). Could also describe a pullup if needed.
+;  5.  Invert (~) - Instead of connecting 1 -> 2 , connect 2 -> 1. reverses the
+;        orientation of the component. Useful for polarizing caps, diodes, etc.
+
+public defenum NetOp:
+  COMPONENT
+  SERIES
+  PARALLEL
+  SHUNT
+  INVERT
+
+; ANT = Abstract Network Tree
+;   ANT are the elements of the tree that might look something like this:
+;
+;  Three Resistors in series
+;  SERIES([ELEM(R1), ELEM(R2), ELEM(R3)])
+;
+;  One resistor in series with two resistors in parallel.
+;  SERIES([ELEM(R1), PARALLEL([ELEM(R2), ELEM(R3)])])
+
+public deftype ANT
+public defmulti get-op (a:ANT) -> NetOp
+public defmulti get-elements (a:ANT) -> Tuple<ANT>
+
+public deftype Component <: ANT
+public defmulti get-value (c:Component) -> Instantiable
+
+public defn Component (i:Instantiable) -> Component:
+  val comp = i
+  new Component:
+    defmethod get-op (this) : COMPONENT
+    defmethod get-elements (this) : []
+    defmethod get-value (this) : comp
+    defmethod print (o:OutputStream, this):
+      print(o, "Comp(%~)" % [name(comp)])
+
+public defn Comp (i:Instantiable) -> Component:
+  Component(i)
+
+public deftype ANTVector <: ANT & Lengthable
+public defmulti add (v:ANTVector, elem:ANT) -> False
+public defmulti add-all (v:ANTVector, elems:Seqable<ANT>) -> False
+defmulti children (v:ANTVector) -> Vector<ANT>
+
+public defmethod add (v:ANTVector, elem:ANT) -> False :
+  val kids = children(v)
+  add(kids, elem)
+
+public defmethod add-all (v:ANTVector, elems:Seqable<ANT>) -> False :
+  val kids = children(v)
+  add-all(kids, elems)
+
+public defmethod length (v:ANTVector) -> Int :
+  length(children(v))
+
+
+public deftype Series <: ANTVector
+
+public defn Series (elems:Tuple<ANT>) -> Series:
+  var kids = Vector<ANT>(length(elems))
+  add-all(kids, elems)
+
+  new Series:
+    defmethod get-op (this) : SERIES
+    defmethod get-elements (this) : to-tuple(kids)
+    defmethod children (this) : kids
+    defmethod print (o:OutputStream, this) :
+      print(o, "Series(%,)" % [kids])
+
+public defn Series () -> Series:
+  Series([])
+
+public deftype Parallel <: ANTVector
+
+public defn Parallel (elems:Tuple<ANT>) -> Parallel:
+  var kids = Vector<ANT>(length(elems))
+  add-all(kids, elems)
+
+  new Parallel:
+    defmethod get-op (this) : PARALLEL
+    defmethod get-elements (this) : to-tuple(kids)
+    defmethod children (this) : kids
+    defmethod print (o:OutputStream, this) :
+      print(o, "Parallel(%,)" % [kids])
+
+public defn Parallel () -> Parallel :
+  Parallel([])
+
+public deftype Shunt <: ANT
+public defmulti get-net (s:Shunt) -> JITXObject
+
+public defn Shunt (n:JITXObject, a:ANT) -> Shunt :
+  val elem = a
+  val _net = n
+
+  new Shunt :
+    defmethod get-op (this) : SHUNT
+    defmethod get-elements (this) : [elem]
+    defmethod get-net (this) : _net
+    defmethod print (o:OutputStream, this) :
+      print(o, "Shunt(%~, net=%~)" % [a, n])
+
+public deftype Invert <: ANT
+
+public defn Invert (a:ANT) -> Invert :
+  val elem = a
+  new Invert :
+    defmethod get-op (this) : INVERT
+    defmethod get-elements (this) : [elem]
+    defmethod print (o:OutputStream, this) :
+      print(o, "Invert: %~" % [a])
+
+public defn get-pin-by-name (obj:JITXObject, name:String) -> Maybe<JITXObject> :
+  label<Maybe<JITXObject>> return:
+    val pat = to-string(".%_" % [name])
+    for p in pins(obj) do:
+      val refName = to-string("%_" % [ref(p)])
+      if suffix?(refName, pat) :
+        return(One(p))
+    return(None())
+
+public defn get-cathode-anode (obj:JITXObject) -> Maybe<[JITXObject, JITXObject]> :
+  val mC = get-pin-by-name(obj, "c")
+  val mA = get-pin-by-name(obj, "a")
+  match(mC, mA) :
+    (oC:One<JITXObject>, oA:One<JITXObject>): One([value(oC), value(oA)])
+    (x,y): None()
+
+public defn get-pins (obj:JITXObject) -> [JITXObject, JITXObject] :
+  ; Given an instantiated object - find the pins that
+  ;  define its interfaces.
+  ;  For caps/resistors, this is usually a tuple `p` of two pins
+  ;  For Diodes, this is usually c / a
+
+  val mCA = get-cathode-anode(obj)
+  match(mCA):
+    (oCA:One<[JITXObject, JITXObject]>):
+      val ret = value(oCA)
+      ret
+    (_:None):
+      [obj.p[1], obj.p[2]]
+
+public defn extrapolate-all (a:ANTVector) -> Seq<[JITXObject, JITXObject]> :
+  inside pcb-module:
+    for elem in get-elements(a) seq:
+      extrapolate(elem)
+
+public defn connect-series (a:Series) -> [JITXObject, JITXObject] :
+  inside pcb-module:
+    val pinSets = to-tuple(extrapolate-all(a))
+    val cnt = length(pinSets)
+
+    ; Series connect all of the components
+    for i in 0 to (cnt - 1) do :
+      net (pinSets[i][1], pinSets[i + 1][0])
+
+    ; Return the first pin and the last pin
+    [pinSets[0][0], pinSets[cnt - 1][1]]
+
+public defn connect-parallel (a:Parallel) -> [JITXObject, JITXObject] :
+  inside pcb-module:
+    val pinSets = to-tuple(extrapolate-all(a))
+    val cnt = length(pinSets)
+
+    ; @TODO - for `shunt` to really do anything - I think I need to
+    ;    check if any of the pins are already connected.
+    ;    If one of the pins is already connected - then we should
+    ;    filter it out from this set.
+    val p1Set = map(get{_, 0}, pinSets)
+    val p2Set = map(get{_, 1}, pinSets)
+    net (p1Set)
+    net (p2Set)
+
+    [p1Set[0], p2Set[0]]
+
+public defn extrapolate (a:ANT) -> [JITXObject, JITXObject] :
+  inside pcb-module :
+    match(a) :
+      (s:Series):
+        ; println("Extrapolate Series: %~" % [s])
+        connect-series(s)
+      (s:Parallel):
+        ;println("Extrapolate Parallel: %~" % [s])
+        connect-parallel(s)
+      (s:Component):
+        ;println("Extrapolate Component: %~" % [s])
+        inst obj : get-value(s)
+        get-pins(obj)
+      (s:Shunt):
+        ;println("Extrapolate Shunt: %~" % [s])
+        val child = get-elements(s)[0]
+        val [p1, p2] = extrapolate(child)
+        val n = get-net(s)
+        ;println("Net: %~" % [n])
+        net (p2, n)
+        [p1, p2]
+      (s:Invert):
+        ;println("Extrapolate Invert: %~" % [s])
+        val child = get-elements(s)[0]
+        val [p1, p2] = extrapolate(child)
+        [p2, p1]
+
+public defn make-circuit (a:ANT) -> Instantiable :
+
+  pcb-module network-circuit:
+    ; pin p[[1 2]]
+    port p : pin[[1 2]]
+    val [p1, p2] = extrapolate(a)
+    net (p[1], p1)
+    net (p[2], p2)
+
+  network-circuit
+
+
+;;;;;;;;;;;;;;;;;;
+; Operators
+;;;;;;;;;;;;;;;;;;
+
+public defn bit-not (a:ANT) -> ANT:
+  Invert(a)
+
+public defn bit-not (a:Instantiable) -> ANT:
+  Invert(Comp(a))
+
+; @TODO - for Series and Parallel, I kind of figure
+;   there will be multiple plusses in a row like this:
+;  R1 + R2 + (R3|R4|Rg|Rf)
+;
+;  It would be nice if there was some pass that collapses
+;  the Parallel(R3, Parallel(R4, Parallel(Rg, Rf))) into
+;      Parallel(R3, R4, Rg, Rf)
+
+public defn plus (a:ANT, b:ANT) -> ANT:
+  Series([a,b])
+
+public defn plus (a:ANT, b:Instantiable) -> ANT :
+  Series([a, Comp(b)])
+
+public defn plus (a:Instantiable, b:ANT) -> ANT :
+  Series([Comp(a), b])
+
+public defn bit-or (a:ANT, b:ANT) -> ANT:
+  Parallel([a,b])
+
+public defn bit-or (a:ANT, b:Instantiable) -> ANT :
+  Parallel([a, Comp(b)])
+
+public defn bit-or (a:Instantiable, b:ANT) -> ANT :
+  Parallel([Comp(a), b])
+
+public defn shift-right (a:ANT, n:JITXObject) -> ANT :
+  Shunt(n, a)

--- a/src/jitx/Utils.stanza
+++ b/src/jitx/Utils.stanza
@@ -1,0 +1,21 @@
+#use-added-syntax(jitx)
+defpackage etools/jitx/Utils :
+  import core
+  import jitx
+  import jitx/commands
+
+public defn instances-rec (mod) -> Seq<JITXObject> :
+  ; Generate a recursive sequence of all the components,
+  ;  modules, etc in the passed module.
+  ; mod could be a JITXObject (instance) or an Instantiable (module definition)
+  ;
+  ; @NOTE - this is primarily to make up for a short coming in the JITx API
+  ;   I think they are planning to address this with a recursive implementation
+  ;   of instances of their own. We can remove at some time in the future.
+  generate<JITXObject>:
+    for child in instances(mod) do:
+      yield(child)
+      for i in instances-rec(child) do :
+        yield(i)
+
+

--- a/tests/CanonicalGround_test.stanza
+++ b/tests/CanonicalGround_test.stanza
@@ -28,6 +28,8 @@ pcb-module test-sub-mod :
 
 pcb-module test-mod :
   inst U1 : comp1
+  if not is-grounded?(U1.GND):
+    fatal("Expected Grounded Pin Here")
   inst U2 : comp2
   val C1 = bypass-cap(U2.VCC, 0.1e-6)
   inst subMod : test-sub-mod

--- a/tests/CanonicalGround_test.stanza
+++ b/tests/CanonicalGround_test.stanza
@@ -5,6 +5,7 @@ defpackage etools/CanonicalGround/jitx-tests :
   import jitx
   import jitx/commands
   import etools/jitx/CanonicalGround
+  import etools/jitx/Utils
 
 pcb-component comp1 :
   pin-properties :
@@ -23,28 +24,36 @@ pcb-component comp2 :
     [VCC | p[3] | Left | 15.0]
 
 pcb-module test-sub-mod :
-  inst U3 : comp1
-  inst U4 : comp2
+  public inst U3 : comp1
+  public inst U4 : comp2
 
 pcb-module test-mod :
-  inst U1 : comp1
+  public inst U1 : comp1
   if not is-grounded?(U1.GND):
     fatal("Expected Grounded Pin Here")
-  inst U2 : comp2
+  public inst U2 : comp2
   val C1 = bypass-cap(U2.VCC, 0.1e-6)
-  inst subMod : test-sub-mod
+  public inst subMod : test-sub-mod
 
 deftest basic-ground-test:
 
   pcb-module top-level :
-    net gnd ()
+    pin asdf ; This is only here so that I can call "connected-pins"
+    net gnd (asdf)
     inst U5 : test-mod
 
     with-ground(gnd)
 
+    val gpins = connected-pins(asdf)
+    ; val pinRefs = map(ref, gpins)
+    ; println("Pins: %," % [pinRefs])
+    #EXPECT(length(connected-pins(asdf)) == 3)
+
   ; for mod in [top-level] do:
   ;   print-def(mod)
 
+  ; @TODO - This is primarily needed to make sure that the
+  ;   top-level gets exercised.
   for comp in component-instances(top-level) do :
     val compName = name(originating-instantiable(comp))
     if compName == "comp1" :

--- a/tests/Network.stanza
+++ b/tests/Network.stanza
@@ -97,3 +97,17 @@ deftest(network) test-shunt :
   print-def(test)
   println("Done")
 
+deftest(network) test-taps :
+
+  val a = Component(res)
+  val b = Component(diode)
+  val series = a + b + Tap("divOut", (a|b|cap))
+
+  pcb-module test:
+    val circuit = make-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+    net (c.p[2], c.divOut)
+
+  print-def(test)
+  println("Done")

--- a/tests/Network.stanza
+++ b/tests/Network.stanza
@@ -1,0 +1,99 @@
+#use-added-syntax(jitx)
+#use-added-syntax(tests)
+defpackage etools/Network-tests :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import etools/jitx/Network
+
+public pcb-component res :
+
+  manufacturer     = "Test"
+  description      = "test resistor"
+  reference-prefix = "R"
+  mpn = "asdf"
+
+; Use unified generator to create pins
+  port p : pin[[1 2]]
+
+public pcb-component cap :
+  manufacturer     = "Test"
+  description      = "test resistor"
+  reference-prefix = "C"
+  mpn = "asdf"
+
+; Use unified generator to create pins
+  port p : pin[[1 2]]
+
+
+public pcb-component diode :
+
+  manufacturer     = "Test"
+  description      = "test resistor"
+  reference-prefix = "D"
+  mpn = "asdf"
+
+; Use unified generator to create pins
+  port c : pin
+  port a : pin
+
+
+deftest(network) test-basic :
+
+  val a = Component(res)
+  val b = Component(diode)
+  val series = Series([a,b])
+
+  pcb-module test:
+    val circuit = make-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+
+deftest(network) test-operators :
+
+  val a = Component(res)
+  val b = Component(diode)
+  val series = a + b + (a|b|cap)
+
+  pcb-module test:
+    val circuit = make-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+
+deftest(network) test-invert :
+
+  pcb-module test:
+    val a = Component(res)
+    val b = Component(diode)
+    val series = a + Invert(b) + a + (~ b)
+
+    val circuit = make-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+
+
+deftest(network) test-shunt :
+
+  pcb-module test:
+    port asdf : pin
+    net gnd (asdf)
+    val a = Component(res)
+    val series = a + (Shunt(gnd, Comp(cap)))
+
+    val circuit = make-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+

--- a/tests/Network.stanza
+++ b/tests/Network.stanza
@@ -86,9 +86,8 @@ deftest(network) test-shunt :
 
   pcb-module test:
     port asdf : pin
-    net gnd (asdf)
     val a = Component(res)
-    val series = a + (Shunt(gnd, Comp(cap)))
+    val series = a + (ShuntGround(Comp(cap)))
 
     val circuit = make-circuit(series)
     inst c : circuit
@@ -96,6 +95,22 @@ deftest(network) test-shunt :
 
   print-def(test)
   println("Done")
+
+deftest(network) test-complex-shunt :
+
+  pcb-module test:
+    port asdf : pin
+    val a = Component(res)
+    val b = Component(diode)
+    val series = a + (b | ShuntGround(Comp(cap)))
+
+    val circuit = make-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+
 
 deftest(network) test-taps :
 


### PR DESCRIPTION
## Abstract Network Tree 

This PR contains the implementation of a new "Abstract Network Tree" (ANT) style method for constructing circuits that contain multiple 2-pin devices. 

The idea is that for all 2-pin devices that have either: 

1.  An array `p` of two pins, indexed 1 & 2.
2.  2 pins with names `c` (cathode) and `a` (anode) 

The user can construct circuits using `Instantiable` and operators. 

Example: 

```
val Rg = Comp(chip-resistor(10.0e3)) 
val Rf = Comp(chip-resistor(27.0e3))
val Cf = Comp(ceramic-cap(1.6e-9))

; Circuit is a instantiation of  the following:
;  
; 
;  p[1]  
;   ----
;         |
;        Rg
;         | 
;       -----
;      |      |
;     Rf     Cf 
;      |      |
;       ------
;          |
; -------
;   p[2] 

inst circ : make-circuit( Rg + (Rf | Cf) )

```

The resulting `circ` is a 2-pin circuit that has a port `p` which is an array of 2-pins, `[1,2]`. This circuit can be passed to subsequent graph constructions. 

## Graph Construction Operators

I've currently defined the following operators: 

1.   Series `+` -  Construct a series concatenation of elements. 
2.   Parallel `|` - Construct a parallel combination of elements. 
3.   Invert  `~` - Rotate the element 180 degrees such that pin 1 is where pin 2 is and vice versa. 
4.   `Tap` - Create a new port on the resulting instantiable that can be accessed. For example, if you wanted a resistive divider, you could `Tap` the bottom resistor to get the output of the resistive divider. 
5.   `ShuntGround` - Insert an element and connect its pin 2 to ground using the `CanonicalGround` module. 
6.   `Comp` - Component element that takes an `Instantiable` as an argument. 